### PR TITLE
PHP 8

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         php:
           - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
 
     name: PHP ${{ matrix.php }} ${{ matrix.db }} tests
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.0'
-          - '7.1'
-          - '7.2'
-          - '7.3'
           - '7.4'
 
     name: PHP ${{ matrix.php }} ${{ matrix.db }} tests

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Composer
         run: composer install --no-progress
 
+      - name: Check CS
+        run: vendor/bin/ecs
+
       - name: PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /composer.lock
+/.phpunit.result.cache

--- a/.runConfigurations/All unit tests.run.xml
+++ b/.runConfigurations/All unit tests.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All unit tests" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
+    <TestRunner configuration_file="$PROJECT_DIR$/phpunit.xml.dist" directory="$PROJECT_DIR$/tests" scope="XML" options="--verbose" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.runConfigurations/EasyCodingStandard.run.xml
+++ b/.runConfigurations/EasyCodingStandard.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="EasyCodingStandard" type="PhpLocalRunConfigurationType" factoryName="PHP Console" path="$PROJECT_DIR$/vendor/bin/ecs" scriptParameters="--fix">
+    <CommandLine workingDirectory="$PROJECT_DIR$">
+      <envs>
+        <env name="XDEBUG_MODE" value="off" />
+      </envs>
+    </CommandLine>
+    <method v="2" />
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Type declarations have been added to all method parameters and return types
+  where possible.
 ### Removed
 - **BC break**: Removed support for PHP versions <= v7.3 as they are no longer
 [actively supported](https://php.net/supported-versions.php) by the PHP project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Add support for PHP v8 .
 - Type declarations have been added to all method parameters and return types
   where possible.
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- **BC break**: Removed support for PHP versions <= v7.3 as they are no longer
+[actively supported](https://php.net/supported-versions.php) by the PHP project.
 
 ## [1.0.1] - 2021-02-30
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7",
+        "php": "^7.4",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.2",
         "sabre/uri": "^2.1.1"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^7",
         "symplify/easy-coding-standard": "^11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8",
+        "phpunit/phpunit": "^9",
         "symplify/easy-coding-standard": "^11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^7",
         "sabre/uri": "^3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.4",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.2",
-        "sabre/uri": "^2.1.1"
+        "sabre/uri": "^3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^6",
+        "symplify/easy-coding-standard": "^11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^8",
         "symplify/easy-coding-standard": "^11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^7",
         "sabre/uri": "^3"

--- a/ecs.php
+++ b/ecs.php
@@ -23,11 +23,5 @@ return static function (ECSConfig $ecsConfig): void {
         // Remove sniff, from common/spaces
         \PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer::class,
         \PhpCsFixer\Fixer\CastNotation\CastSpacesFixer::class,
-
-        // Save strict to later
-        \PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer::class,
-        \PhpCsFixer\Fixer\Strict\StrictParamFixer::class,
-        \PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class,
-        \PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer::class,
     ]);
 };

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $ecsConfig->sets([
+        SetList::COMMON,
+        SetList::PSR_12,
+    ]);
+
+    $ecsConfig->skip([
+        // Remove sniff, from common/control-structures
+        \PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer::class,
+
+        // Remove sniff, from common/spaces
+        \PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer::class,
+        \PhpCsFixer\Fixer\CastNotation\CastSpacesFixer::class,
+
+        // Save strict to later
+        \PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer::class,
+        \PhpCsFixer\Fixer\Strict\StrictParamFixer::class,
+        \PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class,
+        \PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer::class,
+    ]);
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    beStrictAboutOutputDuringTests="true"
+    colors="true"
+>
     <testsuites>
-        <testsuite name="Guzzle Middleware Test Suite">
+        <testsuite name="Phlib Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/AbsoluteUrls.php
+++ b/src/AbsoluteUrls.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Guzzle;
 
-use Sabre\Uri;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Sabre\Uri;
 
 use function GuzzleHttp\Psr7\stream_for;
 
@@ -17,7 +18,6 @@ use function GuzzleHttp\Psr7\stream_for;
 class AbsoluteUrls
 {
     /**
-     * @param callable $handler
      * @return \Closure
      */
     public function __invoke(callable $handler)
@@ -26,7 +26,6 @@ class AbsoluteUrls
             $promise = $handler($request, $options);
             return $promise->then(
                 function (ResponseInterface $response) use ($request) {
-
                     $contentType = $response->getHeaderLine('Content-Type');
                     if (!preg_match('/^text\/html(?:[\t ]*;.*)?$/i', $contentType)) {
                         return $response;
@@ -45,11 +44,6 @@ class AbsoluteUrls
         };
     }
 
-    /**
-     * @param string $content
-     * @param string $baseUrl
-     * @return string
-     */
     private function transform(string $content, string $baseUrl): string
     {
         $baseUrl = Uri\normalize($baseUrl);

--- a/src/AbsoluteUrls.php
+++ b/src/AbsoluteUrls.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Phlib\Guzzle;
 
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Sabre\Uri;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * Class AbsoluteUrls
@@ -29,7 +28,7 @@ class AbsoluteUrls
                     }
 
                     return $response->withBody(
-                        stream_for(
+                        Utils::streamFor(
                             $this->transform(
                                 (string)$response->getBody(),
                                 (string)$request->getUri()

--- a/src/AbsoluteUrls.php
+++ b/src/AbsoluteUrls.php
@@ -17,15 +17,12 @@ use function GuzzleHttp\Psr7\stream_for;
  */
 class AbsoluteUrls
 {
-    /**
-     * @return \Closure
-     */
-    public function __invoke(callable $handler)
+    public function __invoke(callable $handler): \Closure
     {
         return function (RequestInterface $request, $options) use ($handler) {
             $promise = $handler($request, $options);
             return $promise->then(
-                function (ResponseInterface $response) use ($request) {
+                function (ResponseInterface $response) use ($request): ResponseInterface {
                     $contentType = $response->getHeaderLine('Content-Type');
                     if (!preg_match('/^text\/html(?:[\t ]*;.*)?$/i', $contentType)) {
                         return $response;
@@ -57,7 +54,7 @@ class AbsoluteUrls
 
         return preg_replace_callback(
             $search,
-            function (array $matches) use ($baseUrl) {
+            function (array $matches) use ($baseUrl): string {
                 $path = Uri\resolve($baseUrl, $matches[2]);
                 return $matches[1] . $path . $matches[3];
             },

--- a/src/ConvertCharset.php
+++ b/src/ConvertCharset.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Guzzle;
@@ -26,7 +27,6 @@ class ConvertCharset
     private $metaRe = '/(<meta[^>]+charset=["\']?)([a-z][a-z0-9-]+)(["\']?[^>]*>)/i';
 
     /**
-     * @param callable $handler
      * @return \Closure
      */
     public function __invoke(callable $handler)
@@ -35,7 +35,6 @@ class ConvertCharset
             $promise = $handler($request, $options);
             return $promise->then(
                 function (ResponseInterface $response) use ($options) {
-
                     $contentType = $response->getHeaderLine('Content-Type');
                     if (!preg_match('/^text\/html(?:[\t ]*;.*)?$/i', $contentType)) {
                         return $response;
@@ -55,16 +54,11 @@ class ConvertCharset
         };
     }
 
-    /**
-     * @param ResponseInterface $response
-     * @param string $toCharset
-     * @return ResponseInterface
-     */
     private function convertEncoding(ResponseInterface $response, string $toCharset): ResponseInterface
     {
         $fromCharset = $this->getCharset($response);
 
-        $content  = mb_convert_encoding(
+        $content = mb_convert_encoding(
             (string)$response->getBody(),
             $toCharset,
             $fromCharset
@@ -73,11 +67,6 @@ class ConvertCharset
         return $response->withBody(stream_for($content));
     }
 
-    /**
-     * @param ResponseInterface $response
-     * @param string $toCharset
-     * @return ResponseInterface
-     */
     private function rewriteCharset(ResponseInterface $response, string $toCharset): ResponseInterface
     {
         if ($response->hasHeader('Content-Type')) {
@@ -96,8 +85,6 @@ class ConvertCharset
     }
 
     /**
-     * @param ResponseInterface $response
-     * @return string
      * @throws \Exception
      */
     private function getCharset(ResponseInterface $response): string

--- a/src/ConvertCharset.php
+++ b/src/ConvertCharset.php
@@ -16,25 +16,16 @@ use function GuzzleHttp\Psr7\stream_for;
  */
 class ConvertCharset
 {
-    /**
-     * @var string
-     */
-    private $headerRe = '/(charset=)([a-z0-9][a-z0-9-]+)(.*)/i';
+    private string $headerRe = '/(charset=)([a-z0-9][a-z0-9-]+)(.*)/i';
 
-    /**
-     * @var string
-     */
-    private $metaRe = '/(<meta[^>]+charset=["\']?)([a-z][a-z0-9-]+)(["\']?[^>]*>)/i';
+    private string $metaRe = '/(<meta[^>]+charset=["\']?)([a-z][a-z0-9-]+)(["\']?[^>]*>)/i';
 
-    /**
-     * @return \Closure
-     */
-    public function __invoke(callable $handler)
+    public function __invoke(callable $handler): \Closure
     {
         return function (RequestInterface $request, $options) use ($handler) {
             $promise = $handler($request, $options);
             return $promise->then(
-                function (ResponseInterface $response) use ($options) {
+                function (ResponseInterface $response) use ($options): ResponseInterface {
                     $contentType = $response->getHeaderLine('Content-Type');
                     if (!preg_match('/^text\/html(?:[\t ]*;.*)?$/i', $contentType)) {
                         return $response;
@@ -84,9 +75,6 @@ class ConvertCharset
         return $response->withBody(stream_for($content));
     }
 
-    /**
-     * @throws \Exception
-     */
     private function getCharset(ResponseInterface $response): string
     {
         if ($response->hasHeader('Content-Type')) {

--- a/src/ConvertCharset.php
+++ b/src/ConvertCharset.php
@@ -91,6 +91,6 @@ class ConvertCharset
             return $matches[2];
         }
 
-        return mb_detect_encoding((string)$response->getBody());
+        return mb_detect_encoding((string)$response->getBody(), mb_detect_order(), true);
     }
 }

--- a/src/ConvertCharset.php
+++ b/src/ConvertCharset.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Phlib\Guzzle;
 
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * Class ConvertCharset
@@ -55,7 +54,7 @@ class ConvertCharset
             $fromCharset
         );
 
-        return $response->withBody(stream_for($content));
+        return $response->withBody(Utils::streamFor($content));
     }
 
     private function rewriteCharset(ResponseInterface $response, string $toCharset): ResponseInterface
@@ -72,7 +71,7 @@ class ConvertCharset
         $content = (string)$response->getBody();
         $content = preg_replace($this->metaRe, "\$1{$toCharset}\$3", $content);
 
-        return $response->withBody(stream_for($content));
+        return $response->withBody(Utils::streamFor($content));
     }
 
     private function getCharset(ResponseInterface $response): string

--- a/tests/AbsoluteUrlsTest.php
+++ b/tests/AbsoluteUrlsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Guzzle;
@@ -14,17 +15,18 @@ class AbsoluteUrlsTest extends TestCase
 {
     /**
      * @dataProvider transformFullPageProvider
-     * @param string $baseUrl
-     * @param string $preFile
-     * @param string $postFile
      */
     public function testTransformFullPage(string $baseUrl, string $preFile, string $postFile)
     {
-        $response = new Response(200, [ 'Content-Type' => 'text/html' ], file_get_contents($preFile));
+        $response = new Response(200, [
+            'Content-Type' => 'text/html',
+        ], file_get_contents($preFile));
 
         $handler = new HandlerStack(new MockHandler([$response]));
         $handler->push(new AbsoluteUrls());
-        $client = new HttpClient(['handler' => $handler]);
+        $client = new HttpClient([
+            'handler' => $handler,
+        ]);
         $response = $client->get($baseUrl);
 
         Assert::assertSame(
@@ -39,24 +41,25 @@ class AbsoluteUrlsTest extends TestCase
             [
                 'https://example.com/foo/bar/world',
                 __DIR__ . '/_files/AbsoluteUrls/pre.html',
-                __DIR__ . '/_files/AbsoluteUrls/post.html'
-            ]
+                __DIR__ . '/_files/AbsoluteUrls/post.html',
+            ],
         ];
     }
 
     /**
      * @dataProvider transformProvider
-     * @param string $baseUrl
-     * @param string $source
-     * @param string $expected
      */
     public function testTransform(string $baseUrl, string $source, string $expected)
     {
-        $response = new Response(200, [ 'Content-Type' => 'text/html' ], $source);
+        $response = new Response(200, [
+            'Content-Type' => 'text/html',
+        ], $source);
 
         $handler = new HandlerStack(new MockHandler([$response]));
         $handler->push(new AbsoluteUrls());
-        $client = new HttpClient(['handler' => $handler]);
+        $client = new HttpClient([
+            'handler' => $handler,
+        ]);
         $response = $client->get($baseUrl);
 
         $this->assertSame(
@@ -71,197 +74,197 @@ class AbsoluteUrlsTest extends TestCase
             [
                 'http://example.com',
                 '<a href="#">',
-                '<a href="http://example.com/">'
+                '<a href="http://example.com/">',
             ],
             [
                 'http://example.com/test1/test2/tmp.html',
                 '<a href="http://example.com/test1/page2.html">',
-                '<a href="http://example.com/test1/page2.html">'
+                '<a href="http://example.com/test1/page2.html">',
             ],
             [
                 'http://example.com/test1/test2/tmp.html',
                 '<a href="../page2.html">',
-                '<a href="http://example.com/test1/page2.html">'
+                '<a href="http://example.com/test1/page2.html">',
             ],
             [
                 'http://example.com/test1/test2/tmp.html',
                 '<a href="mailto:test@example.com">',
-                '<a href="mailto:test@example.com">'
+                '<a href="mailto:test@example.com">',
             ],
 
             // absolutely relative, shallow URL path
             [
                 'http://example.com/tmp.html',
                 '<body background="/images/bg.jpg">',
-                '<body background="http://example.com/images/bg.jpg">'
+                '<body background="http://example.com/images/bg.jpg">',
             ],
             [
                 'http://example.com/tmp.html',
                 "div { background: url('/images/bg.gif'); }",
-                "div { background: url('http://example.com/images/bg.gif'); }"
+                "div { background: url('http://example.com/images/bg.gif'); }",
             ],
             [
                 'http://example.com/tmp.html',
                 '<img src="/images/default.png">',
-                '<img src="http://example.com/images/default.png">'
+                '<img src="http://example.com/images/default.png">',
             ],
             [
                 'http://example.com/tmp.html',
                 '<a href="/page2.html">',
-                '<a href="http://example.com/page2.html">'
+                '<a href="http://example.com/page2.html">',
             ],
 
             // relative, shallow URL path
             [
                 'http://example.com/tmp.html',
                 '<body background="images/bg.jpg">',
-                '<body background="http://example.com/images/bg.jpg">'
+                '<body background="http://example.com/images/bg.jpg">',
             ],
             [
                 'http://example.com/tmp.html',
                 "div { background: url('images/bg.gif'); }",
-                "div { background: url('http://example.com/images/bg.gif'); }"
+                "div { background: url('http://example.com/images/bg.gif'); }",
             ],
             [
                 'http://example.com/tmp.html',
                 '<img src="images/default.png">',
-                '<img src="http://example.com/images/default.png">'
+                '<img src="http://example.com/images/default.png">',
             ],
             [
                 'http://example.com/tmp.html',
                 '<a href="page2.html">',
-                '<a href="http://example.com/page2.html">'
+                '<a href="http://example.com/page2.html">',
             ],
 
             // absolute, shallow URL path
             [
                 'http://example.com/tmp.html',
                 '<body background="http://example.com/images/bg.jpg">',
-                '<body background="http://example.com/images/bg.jpg">'
+                '<body background="http://example.com/images/bg.jpg">',
             ],
             [
                 'http://example.com/tmp.html',
                 "div { background: url('http://example.com/images/bg.gif'); }",
-                "div { background: url('http://example.com/images/bg.gif'); }"
+                "div { background: url('http://example.com/images/bg.gif'); }",
             ],
             [
                 'http://example.com/tmp.html',
                 '<img src="http://example.com/images/default.png">',
-                '<img src="http://example.com/images/default.png">'
+                '<img src="http://example.com/images/default.png">',
             ],
             [
                 'http://example.com/tmp.html',
                 '<a href="http://example.com/page2.html">',
-                '<a href="http://example.com/page2.html">'
+                '<a href="http://example.com/page2.html">',
             ],
 
             // absolutely relative, one deep URL path
             [
                 'http://example.com/path/tmp.html',
                 '<body background="/images/bg.jpg">',
-                '<body background="http://example.com/images/bg.jpg">'
+                '<body background="http://example.com/images/bg.jpg">',
             ],
             [
                 'http://example.com/path/tmp.html',
                 "div { background: url('/images/bg.gif'); }",
-                "div { background: url('http://example.com/images/bg.gif'); }"
+                "div { background: url('http://example.com/images/bg.gif'); }",
             ],
             [
                 'http://example.com/path/tmp.html',
-                '<img src="/images/default.png">', '<img src="http://example.com/images/default.png">'
+                '<img src="/images/default.png">', '<img src="http://example.com/images/default.png">',
             ],
             [
                 'http://example.com/path/tmp.html',
                 '<a href="/page2.html">',
-                '<a href="http://example.com/page2.html">'
+                '<a href="http://example.com/page2.html">',
             ],
 
             // relative, one deep URL path
             [
                 'http://example.com/path/tmp.html',
                 '<body background="images/bg.jpg">',
-                '<body background="http://example.com/path/images/bg.jpg">'
+                '<body background="http://example.com/path/images/bg.jpg">',
             ],
             [
                 'http://example.com/path/tmp.html',
                 "div { background: url('images/bg.gif'); }",
-                "div { background: url('http://example.com/path/images/bg.gif'); }"
+                "div { background: url('http://example.com/path/images/bg.gif'); }",
             ],
             [
                 'http://example.com/path/tmp.html',
                 '<img src="images/default.png">',
-                '<img src="http://example.com/path/images/default.png">'
+                '<img src="http://example.com/path/images/default.png">',
             ],
             [
                 'http://example.com/path/tmp.html',
                 '<a href="page2.html">',
-                '<a href="http://example.com/path/page2.html">'
+                '<a href="http://example.com/path/page2.html">',
             ],
 
             // absolute, one deep URL path
             [
                 'http://example.com/path/tmp.html',
                 '<body background="http://example.com/images/bg.jpg">',
-                '<body background="http://example.com/images/bg.jpg">'
+                '<body background="http://example.com/images/bg.jpg">',
             ],
             [
                 'http://example.com/path/tmp.html',
                 "div { background: url('http://example.com/images/bg.gif'); }",
-                "div { background: url('http://example.com/images/bg.gif'); }"
+                "div { background: url('http://example.com/images/bg.gif'); }",
             ],
             [
                 'http://example.com/path/tmp.html',
                 '<img src="http://example.com/images/default.png">',
-                '<img src="http://example.com/images/default.png">'
+                '<img src="http://example.com/images/default.png">',
             ],
             [
                 'http://example.com/path/tmp.html',
                 '<a href="http://example.com/page2.html">',
-                '<a href="http://example.com/page2.html">'
+                '<a href="http://example.com/page2.html">',
             ],
 
             // absolutely relative, two deep URL path
             [
                 'http://example.com/path/to/tmp.html',
                 '<body background="/images/bg.jpg">',
-                '<body background="http://example.com/images/bg.jpg">'
+                '<body background="http://example.com/images/bg.jpg">',
             ],
             [
                 'http://example.com/path/to/tmp.html',
                 "div { background: url('/images/bg.gif'); }",
-                "div { background: url('http://example.com/images/bg.gif'); }"
+                "div { background: url('http://example.com/images/bg.gif'); }",
             ],
             [
                 'http://example.com/path/to/tmp.html',
                 '<img src="/images/default.png">',
-                '<img src="http://example.com/images/default.png">'
+                '<img src="http://example.com/images/default.png">',
             ],
             [
                 'http://example.com/path/to/tmp.html',
                 '<a href="/page2.html">',
-                '<a href="http://example.com/page2.html">'
+                '<a href="http://example.com/page2.html">',
             ],
 
             // relative, two deep URL path
             [
                 'http://example.com/path/to/tmp.html',
                 '<body background="images/bg.jpg">',
-                '<body background="http://example.com/path/to/images/bg.jpg">'
+                '<body background="http://example.com/path/to/images/bg.jpg">',
             ],
             [
                 'http://example.com/path/to/tmp.html',
                 "div { background: url('images/bg.gif'); }",
-                "div { background: url('http://example.com/path/to/images/bg.gif'); }"
+                "div { background: url('http://example.com/path/to/images/bg.gif'); }",
             ],
             [
                 'http://example.com/path/to/tmp.html',
                 '<img src="images/default.png">',
-                '<img src="http://example.com/path/to/images/default.png">'
+                '<img src="http://example.com/path/to/images/default.png">',
             ],
             [
                 'http://example.com/path/to/tmp.html',
                 '<a href="page2.html">',
-                '<a href="http://example.com/path/to/page2.html">'
+                '<a href="http://example.com/path/to/page2.html">',
             ],
         ];
     }
@@ -271,42 +274,44 @@ class AbsoluteUrlsTest extends TestCase
         return [
             [
                 'text/html',
-                'assertNotSame'
+                'assertNotSame',
             ],
             [
                 'text/html; charset=utf8',
-                'assertNotSame'
+                'assertNotSame',
             ],
             [
                 'text/html+x',
-                'assertSame'
+                'assertSame',
             ],
             [
                 'application/json',
-                'assertSame'
+                'assertSame',
             ],
         ];
     }
 
     /**
      * @dataProvider onlyTextHtmlProvider
-     * @param string $contentType
-     * @param string $assertion
      */
     public function testOnlyTextHtml(string $contentType, string $assertion)
     {
         $baseUrl = 'http://example.com/path/to/tmp.html';
         $source = '<a href="page2.html">';
 
-        $response = new Response(200, [ 'Content-Type' => $contentType ], $source);
+        $response = new Response(200, [
+            'Content-Type' => $contentType,
+        ], $source);
 
         $handler = new HandlerStack(new MockHandler([$response]));
         $handler->push(new AbsoluteUrls());
-        $client = new HttpClient(['handler' => $handler]);
+        $client = new HttpClient([
+            'handler' => $handler,
+        ]);
         $response = $client->get($baseUrl);
 
         $actual = (string)$response->getBody();
 
-        $this->$assertion($source, $actual);
+        $this->{$assertion}($source, $actual);
     }
 }

--- a/tests/AbsoluteUrlsTest.php
+++ b/tests/AbsoluteUrlsTest.php
@@ -16,7 +16,7 @@ class AbsoluteUrlsTest extends TestCase
     /**
      * @dataProvider transformFullPageProvider
      */
-    public function testTransformFullPage(string $baseUrl, string $preFile, string $postFile)
+    public function testTransformFullPage(string $baseUrl, string $preFile, string $postFile): void
     {
         $response = new Response(200, [
             'Content-Type' => 'text/html',
@@ -35,7 +35,7 @@ class AbsoluteUrlsTest extends TestCase
         );
     }
 
-    public function transformFullPageProvider()
+    public function transformFullPageProvider(): array
     {
         return [
             [
@@ -49,7 +49,7 @@ class AbsoluteUrlsTest extends TestCase
     /**
      * @dataProvider transformProvider
      */
-    public function testTransform(string $baseUrl, string $source, string $expected)
+    public function testTransform(string $baseUrl, string $source, string $expected): void
     {
         $response = new Response(200, [
             'Content-Type' => 'text/html',
@@ -68,7 +68,7 @@ class AbsoluteUrlsTest extends TestCase
         );
     }
 
-    public function transformProvider()
+    public function transformProvider(): array
     {
         return [
             [
@@ -269,7 +269,7 @@ class AbsoluteUrlsTest extends TestCase
         ];
     }
 
-    public function onlyTextHtmlProvider()
+    public function onlyTextHtmlProvider(): array
     {
         return [
             [
@@ -294,7 +294,7 @@ class AbsoluteUrlsTest extends TestCase
     /**
      * @dataProvider onlyTextHtmlProvider
      */
-    public function testOnlyTextHtml(string $contentType, string $assertion)
+    public function testOnlyTextHtml(string $contentType, string $assertion): void
     {
         $baseUrl = 'http://example.com/path/to/tmp.html';
         $source = '<a href="page2.html">';

--- a/tests/ConvertCharsetTest.php
+++ b/tests/ConvertCharsetTest.php
@@ -15,7 +15,7 @@ class ConvertCharsetTest extends TestCase
     /**
      * @dataProvider metaProvider
      */
-    public function testMeta(string $toCharset, string $preFile, string $postFile)
+    public function testMeta(string $toCharset, string $preFile, string $postFile): void
     {
         $response = new Response(200, [
             'Content-Type' => 'text/html',
@@ -35,7 +35,7 @@ class ConvertCharsetTest extends TestCase
         );
     }
 
-    public function metaProvider()
+    public function metaProvider(): array
     {
         return [
             [
@@ -156,7 +156,7 @@ class ConvertCharsetTest extends TestCase
     /**
      * @dataProvider headerProvider
      */
-    public function testHeader(string $header, string $preFile, string $postFile)
+    public function testHeader(string $header, string $preFile, string $postFile): void
     {
         $response = new Response(200, [
             'Content-Type' => $header,
@@ -176,7 +176,7 @@ class ConvertCharsetTest extends TestCase
         );
     }
 
-    public function headerProvider()
+    public function headerProvider(): array
     {
         return [
             [

--- a/tests/ConvertCharsetTest.php
+++ b/tests/ConvertCharsetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Guzzle;
@@ -13,19 +14,18 @@ class ConvertCharsetTest extends TestCase
 {
     /**
      * @dataProvider metaProvider
-     * @param string $toCharset
-     * @param string $preFile
-     * @param string $postFile
      */
     public function testMeta(string $toCharset, string $preFile, string $postFile)
     {
-        $response = new Response(200, [ 'Content-Type' => 'text/html' ], file_get_contents($preFile));
+        $response = new Response(200, [
+            'Content-Type' => 'text/html',
+        ], file_get_contents($preFile));
 
         $handler = new HandlerStack(new MockHandler([$response]));
         $handler->push(new ConvertCharset());
         $client = new HttpClient([
             'convert_charset' => $toCharset,
-            'handler'         => $handler
+            'handler' => $handler,
         ]);
         $response = $client->get('http://www.example.com/');
 
@@ -155,19 +155,18 @@ class ConvertCharsetTest extends TestCase
 
     /**
      * @dataProvider headerProvider
-     * @param string $header
-     * @param string $preFile
-     * @param string $postFile
      */
     public function testHeader(string $header, string $preFile, string $postFile)
     {
         $response = new Response(200, [
-            'Content-Type' => $header
+            'Content-Type' => $header,
         ], file_get_contents($preFile));
 
         $handler = new HandlerStack(new MockHandler([$response]));
         $handler->push(new ConvertCharset());
-        $client = new HttpClient(['handler' => $handler]);
+        $client = new HttpClient([
+            'handler' => $handler,
+        ]);
         $response = $client->get('http://www.example.com/');
 
         $this->assertSame(


### PR DESCRIPTION
- Remove support for PHP <= v7.3
- Add type declarations
- Upgrade PHPUnit to v9
- Upgrade sabre/uri to v3
- Upgrade Guzzle to v7
- Add support for PHP v8